### PR TITLE
Update python dependency to reflect version required for numpy1.26.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 - Docker
 - Docker compose
-- Python 3
+- Python 3.9+
 
 ```
 sudo apt install python


### PR DESCRIPTION
Ran into an issue installing requirements on python 3.8 
- Updated readme to reflect python version requirement 
- numpy 1.26.4 requires at least python3.9 - [https://numpy.org/devdocs/release/1.26.4-notes.html](https://numpy.org/devdocs/release/1.26.4-notes.html)